### PR TITLE
Multiple fixes

### DIFF
--- a/lib/nasldoc/assets/js/shBrushNasl.js
+++ b/lib/nasldoc/assets/js/shBrushNasl.js
@@ -7,7 +7,8 @@
 		var constants	= 'FALSE NULL TRUE';
 
 		var keywords	= 'break continue else export for foreach function global_var if ' +
-				  'import include local_var repeat return until while';
+				  'import include local_var repeat return until while namespace object ' +
+                                  'var public private case switch default do';
 
 		this.regexList = [
 			{ regex: SyntaxHighlighter.regexLib.singleLinePerlComments,		css: 'comment' },

--- a/lib/nasldoc/cli/application.rb
+++ b/lib/nasldoc/cli/application.rb
@@ -253,29 +253,25 @@ module NaslDoc
 			def remove_blacklist file_list
 				blacklist = [
 					"apple_device_model_list.inc",
-					"blacklist_dss.inc",
-					"blacklist_rsa.inc",
-					"blacklist_ssl_rsa1024.inc",
-					"blacklist_ssl_rsa2048.inc",
+					"blacklist_",
 					"custom_CA.inc",
-					"daily_badip.inc",
-					"daily_badip2.inc",
+					"daily_badip",
 					"daily_badurl.inc",
 					"known_CA.inc",
 					"oui.inc",
 					"oval-definitions-schematron.inc",
-					"ovaldi32-rhel5.inc",
-					"ovaldi32-win-dyn-v100.inc",
-					"ovaldi32-win-dyn-v90.inc",
-					"ovaldi32-win-static.inc",
-					"ovaldi64-rhel5.inc",
-					"ovaldi64-win-dyn-v100.inc",
-					"ovaldi64-win-dyn-v90.inc",
-					"ovaldi64-win-static.inc",
 					"plugin_feed_info.inc",
 					"sc_families.inc",
 					"scap_schema.inc",
-					"ssl_known_cert.inc"
+					"ssl_known_cert.inc",
+                                        "ssh_get_info2",
+                                        "torture_cgi",
+                                        "daily_badip3.inc",
+                                        "cisco_ios.inc",
+					"ovaldi32",
+					"ovaldi64",
+					"os_cves.inc",
+                                        "kernel_cves.inc"
 				]
 
 				new_file_list = file_list.dup

--- a/lib/nasldoc/templates/file.erb
+++ b/lib/nasldoc/templates/file.erb
@@ -371,11 +371,11 @@
 
 		<h3>Code</h3>
                 <!-- The contents must not have indentation, else formatting is off. -->
-		<pre class="brush: nasl">
+<script type="syntaxhighlighter" class="brush: nasl"><![CDATA[ 
 <% unless @functions[name][:code].nil? %>
-<%= CGI::escapeHTML(@functions[name][:code]) %>
+<%= @functions[name][:code] %>
 <% end %>
-		</pre>
+]]></script>
 		<a href="#top">top</a>
 		<hr>
 		<% end %>
@@ -388,7 +388,7 @@
 	<hr>
 
 	<footer>
-		<p>&copy; Tenable Network Security 2018</p>
+		<p>&copy; Tenable Network Security <%= Time.new.year %></p>
 	</footer>
 
   </div><!--/.fluid-container-->

--- a/lib/nasldoc/templates/index.erb
+++ b/lib/nasldoc/templates/index.erb
@@ -71,6 +71,7 @@
 				<div class="span9">
 					<div class="hero-unit">
 						<h1>Welcome to nasldoc!</h1>
+                                                <h3> Generated <%= Time.now.inspect %></h3>
 						<p>Select a file to view the docs!</p>
 						<p><a class="btn btn-primary btn-large">Learn more &raquo;</a></p>
 					</div>
@@ -82,7 +83,7 @@
 			<hr>
 
 			<footer>
-				<p>&copy; Tenable Network Security 2018</p>
+				<p>&copy; Tenable Network Security <%= Time.new.year %></p>
 			</footer>
 
 		</div><!--/.fluid-container-->


### PR DESCRIPTION
- Removed hard coded copyright year from template
- Added generated timestamp to documentation home page
- Added new keywords to syntax highlighter js file
- Use CDATA blocks rather than pre for code snippets to fix issue with html entities being displayed for html tag characters. This fixes https://github.com/tenable/nasldoc/issues/2